### PR TITLE
Draft: Fix support for kernel rollback protection

### DIFF
--- a/completions/_mkdepthcharge.bash
+++ b/completions/_mkdepthcharge.bash
@@ -34,7 +34,7 @@ _mkdepthcharge() {
         --ramdisk-load-address --patch-dtbs --no-patch-dtbs
         --pad-vmlinuz --no-pad-vmlinuz
         --set-init-size --no-set-init-size
-        -c --cmdline --kern-guid --no-kern-guid --bootloader
+        -c --cmdline --kern-guid --no-kern-guid --kernel-version --bootloader
         --keydir --keyblock --signprivate --signpubkey
     )
 
@@ -56,6 +56,7 @@ _mkdepthcharge() {
         --ramdisk-load-address) : ;;
         -c|--cmdline)   _mkdepthcharge__cmdline ;;
         --tmpdir)       _mkdepthcharge__file ;;
+        --kernel-version) : ;;
         --bootloader)   _mkdepthcharge__file ;;
         --keydir)       _mkdepthcharge__file ;;
         --keyblock)     _mkdepthcharge__file ;;

--- a/completions/_mkdepthcharge.zsh
+++ b/completions/_mkdepthcharge.zsh
@@ -30,6 +30,7 @@ function _mkdepthcharge {
         '*'{-c,--cmdline}'[Command-line parameters for the kernel.]:*:kernel cmdline:{_mkdepthcharge__cmdline}' \
         --kern-guid'[Prepend kern_guid=%U to the cmdline.]' \
         --no-kern-guid'[Do not prepend kern_guid=%U to the cmdline.]' \
+        --kernel-version'[Set the kernel version parameter.]' \
         --bootloader'[Bootloader stub binary to use.]:bootloader file:_files' \
         --keydir'[Directory containing vboot keys to use.]:keys dir:_directories' \
         --keyblock'[The key block file (.keyblock).]:keyblock file:_files' \

--- a/depthcharge_tools/mkdepthcharge.py
+++ b/depthcharge_tools/mkdepthcharge.py
@@ -623,7 +623,7 @@ class mkdepthcharge(
         return kern_guid
 
     @vboot_options.add
-    @Argument("--kern-ver", nargs=1,
+    @Argument("--kernel-version", nargs=1,
               help="Set the kernel version parameter.")
     def kern_ver(self, version=1):
         """Kernel version for rollback protection."""

--- a/depthcharge_tools/mkdepthcharge.py
+++ b/depthcharge_tools/mkdepthcharge.py
@@ -623,6 +623,16 @@ class mkdepthcharge(
         return kern_guid
 
     @vboot_options.add
+    @Argument("--kern-ver", nargs=1,
+              help="Set the kernel version parameter.")
+    def kern_ver(self, version=1):
+        """Kernel version for rollback protection."""
+        if not version.isdigit():
+            raise ValueError(
+                    "Version argument must be a positive integer.")
+        return version
+
+    @vboot_options.add
     @Argument("--bootloader", nargs=1)
     def bootloader(self, file_=None):
         """Bootloader stub binary to use."""
@@ -928,7 +938,7 @@ class mkdepthcharge(
 
             self.logger.info("Packing files as depthcharge image.")
             proc = vbutil_kernel(
-                "--version", "1",
+                "--version", self.kern_ver,
                 "--arch", self.arch.vboot,
                 "--vmlinuz", fit_image,
                 "--config", cmdline_file,
@@ -942,7 +952,7 @@ class mkdepthcharge(
         elif self.image_format == "zimage" and initramfs is None:
             self.logger.info("Packing files as depthcharge image.")
             proc = vbutil_kernel(
-                "--version", "1",
+                "--version", self.kern_ver,
                 "--arch", self.arch.vboot,
                 "--vmlinuz", vmlinuz,
                 "--config", cmdline_file,
@@ -995,7 +1005,7 @@ class mkdepthcharge(
             self.logger.info("Packing files as temporary image.")
             temp_img = self._tempfile("temp.img")
             proc = vbutil_kernel(
-                "--version", "1",
+                "--version", self.kern_ver,
                 "--arch", self.arch.vboot,
                 "--vmlinuz", vmlinuz,
                 "--config", cmdline_file,


### PR DESCRIPTION
As mentioned in #7, exposing the `--version` parameter would be beneficial. The command line option works however it is currently lacking documentation and a option in the config file.