### PR TITLE
Fix syntax of Python regex escape sequences

### DIFF
--- a/depthcharge_tools/depthchargectl/__init__.py
+++ b/depthcharge_tools/depthchargectl/__init__.py
@@ -77,16 +77,16 @@ class Board:
 
         # Try to detect non-regex values and extend them to match any
         # rev/sku, but if a rev/sku is given match only the given one.
-        if pattern and re.fullmatch("[\w,-]+", pattern):
+        if pattern and re.fullmatch(r"[\w,-]+", pattern):
             prefix, rev, sku = re.fullmatch(
-                "(.*?)(-rev\d+)?(-sku\d+)?",
+                r"(.*?)(-rev\d+)?(-sku\d+)?",
                 pattern,
             ).groups()
 
             pattern = "{}{}{}".format(
                 prefix,
-                rev or "(-rev\d+)?",
-                sku or "(-sku\d+)?",
+                rev or r"(-rev\d+)?",
+                sku or r"(-sku\d+)?",
             )
 
         if pattern:

--- a/depthcharge_tools/utils/string.py
+++ b/depthcharge_tools/utils/string.py
@@ -57,7 +57,7 @@ def parse_bytesize(val):
 
     try:
         s = str(val)
-        suffix = re.search("[a-zA-Z\s]*\Z", s)[0].strip()
+        suffix = re.search(r"[a-zA-Z\s]*\Z", s)[0].strip()
         number = s.rpartition(suffix)[0].strip()
         multiplier = bytesize_suffixes[suffix]
         return int(ast.literal_eval(number)) * multiplier

--- a/depthcharge_tools/utils/subprocess.py
+++ b/depthcharge_tools/utils/subprocess.py
@@ -402,7 +402,7 @@ class FdtgetRunner(ProcessRunner):
 
         # str.split takes too much memory
         def split(s):
-            for m in re.finditer("(\S*)\s", s):
+            for m in re.finditer(r"(\S*)\s", s):
                 yield m.group()
 
         if type in (None, int):

--- a/update_config.py
+++ b/update_config.py
@@ -169,7 +169,7 @@ class update_config(
                 block["hwidmatch"] = None
 
             else:
-                m = re.match("^\^?\(?([0-9A-Z]+)[^0-9A-Za-z]", hwidmatch)
+                m = re.match(r"^\^?\(?([0-9A-Z]+)[^0-9A-Za-z]", hwidmatch)
                 if m:
                     codename = m.group(1).lower()
                 else:
@@ -340,7 +340,7 @@ class update_config(
                 elif line.startswith("string"):
                     type_ = lambda s: str.strip(s, "'\"")
 
-                m = re.match("default (\S+|\".+\")$", line)
+                m = re.match(r'default (\S+|".+")$', line)
                 try:
                     value = type_(m.group(1).strip("'\""))
                 except ValueError:
@@ -352,7 +352,7 @@ class update_config(
                         defaults[config][None] = value
                     value = None
 
-                m = re.match("default (\S+|\".+\") if ([0-9A-Z_]+)", line)
+                m = re.match(r'default (\S+|".+") if ([0-9A-Z_]+)', line)
                 try:
                     value = type_(m.group(1))
                     cond = m.group(2)
@@ -397,12 +397,12 @@ class update_config(
                 if config is None:
                     continue
 
-                m = re.match("select (\S+|\".+\")$", line)
+                m = re.match(r'select (\S+|".+")$', line)
                 if m:
                     value = m.group(1).strip("'\"")
                     selects[config][None].append(value)
 
-                m = re.match("select (\S+|\".+\") if ([0-9A-Z_]+)", line)
+                m = re.match(r'select (\S+|".+") if ([0-9A-Z_]+)', line)
                 if m:
                     value = m.group(1)
                     cond = m.group(2)
@@ -1076,8 +1076,8 @@ class update_config(
             board_c = board_c.read_text() if board_c.is_file() else ""
             if block.get("KERNEL_FIT", False):
                 m = re.search(
-                    'fit_(?:add|set)_compat(?:_by_rev)?\('
-                    '"([^"]+?)(?:-rev[^-]+|-sku[^-]+)*"',
+                    r'fit_(?:add|set)_compat(?:_by_rev)?\('
+                    r'"([^"]+?)(?:-rev[^-]+|-sku[^-]+)*"',
                     board_c,
                 )
                 if m:


### PR DESCRIPTION
This fixes `W605` warnings from `flake8`, and Python 3.12 now emits `SyntaxWarning`s for these:

  https://docs.python.org/3/whatsnew/3.12.html#other-language-changes